### PR TITLE
refactor: query builder 형식 변경 및 쿼리 최적화

### DIFF
--- a/src/common/entity/base.constraints.ts
+++ b/src/common/entity/base.constraints.ts
@@ -2,6 +2,8 @@ export class DBConstraints {
   static readonly BASIC_STRING = 'varchar';
   static readonly BASIC_TEXT = 'text';
   static readonly BASIC_NUMBER = 'int';
+
+  static readonly ID = 'id';
 }
 
 export class CommonConstraints {

--- a/src/database/typeormConfig.service.ts
+++ b/src/database/typeormConfig.service.ts
@@ -13,9 +13,9 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       username: this.configService.get('DB_USERNAME'),
       password: this.configService.get('DB_PASSWORD'),
       database: this.configService.get('DB_DATABASE'),
-      synchronize: true,
       autoLoadEntities: true,
       timezone: 'Z', // UTC로 저장
+      logging: true,
     };
   }
 }

--- a/src/order/entity/order.entity.ts
+++ b/src/order/entity/order.entity.ts
@@ -39,7 +39,10 @@ export class OrderEntity extends MyBaseEntity implements IOrderEntity {
   userId: number;
 
   @ManyToOne(() => UserEntity, (user) => user.orders)
-  @JoinColumn({ name: 'userId', referencedColumnName: 'id' })
+  @JoinColumn({
+    name: 'userId',
+    referencedColumnName: CommonConstraints.DB_CONSTRAINTS.ID,
+  })
   user: UserEntity;
 
   @Column({

--- a/src/orderDetail/entity/orderDetail.entity.ts
+++ b/src/orderDetail/entity/orderDetail.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, Relation } from 'typeorm';
 import { IBaseEntity, MyBaseEntity } from '../../common/entity/base';
 import { CommonConstraints } from '../../common/entity/base.constraints';
 import { OrderEntity } from '../../order/entity/order.entity';
@@ -20,8 +20,11 @@ export class OrderDetailEntity extends MyBaseEntity implements IOrderDetail {
   orderId: number;
 
   @ManyToOne(() => OrderEntity, (order) => order.orderDetails)
-  @JoinColumn({ name: 'orderId', referencedColumnName: 'id' })
-  order: OrderEntity;
+  @JoinColumn({
+    name: 'orderId',
+    referencedColumnName: CommonConstraints.DB_CONSTRAINTS.ID,
+  })
+  order: Relation<OrderEntity>;
 
   @Column({
     type: CommonConstraints.DB_CONSTRAINTS.BASIC_NUMBER,
@@ -29,8 +32,11 @@ export class OrderDetailEntity extends MyBaseEntity implements IOrderDetail {
   productId: number;
 
   @ManyToOne(() => ProductEntity, (product) => product.orderDetails)
-  @JoinColumn({ name: 'productId', referencedColumnName: 'id' })
-  product: ProductEntity;
+  @JoinColumn({
+    name: 'productId',
+    referencedColumnName: CommonConstraints.DB_CONSTRAINTS.ID,
+  })
+  product: Relation<ProductEntity>;
 
   @Column({
     type: CommonConstraints.DB_CONSTRAINTS.BASIC_NUMBER,

--- a/src/product/entity/product.entity.ts
+++ b/src/product/entity/product.entity.ts
@@ -40,7 +40,7 @@ export class ProductEntity extends MyBaseEntity implements IProductEntity {
   })
   stocks: number;
 
-  @OneToMany(() => OrderDetailEntity, (orderDetail) => orderDetail.order)
+  @OneToMany(() => OrderDetailEntity, (orderDetail) => orderDetail.product)
   orderDetails: OrderDetailEntity[];
 
   constructor(param?: IProductEntity) {

--- a/src/product/product.controller.ts
+++ b/src/product/product.controller.ts
@@ -1,20 +1,20 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
 import { ProductService } from './product.service';
 
 @Controller('products')
 export class ProductsController {
   constructor(private productService: ProductService) {}
 
-  @Get('/popular')
+  @Get('popular')
   async getPopular(
-    @Query('limit') limit: string,
-    @Query('month') month: string,
-    @Query('priceFrom') priceFrom: string,
-    @Query('priceTo') priceTo: string,
+    @Query('limit', ParseIntPipe) limit: number,
+    @Query('month', ParseIntPipe) month: number,
+    @Query('minPrice', ParseIntPipe) minPrice: number,
+    @Query('maxPrice', ParseIntPipe) maxPrice: number,
   ) {
     return await this.productService.getPopularTopK(limit, month, {
-      from: priceFrom,
-      to: priceTo,
+      min: minPrice,
+      max: maxPrice,
     });
   }
 }

--- a/src/product/product.module.ts
+++ b/src/product/product.module.ts
@@ -3,10 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProductEntity } from './entity/product.entity';
 import { ProductsController } from './product.controller';
 import { ProductService } from './product.service';
+import { ProductDataAccess } from './product.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ProductEntity])],
   controllers: [ProductsController],
-  providers: [ProductService],
+  providers: [ProductService, ProductDataAccess],
 })
 export class ProductModule {}

--- a/src/product/product.repository.ts
+++ b/src/product/product.repository.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PersistedProductEntity, ProductEntity } from './entity/product.entity';
+import { Repository } from 'typeorm';
+import { OrderDetailEntity } from '../orderDetail/entity/orderDetail.entity';
+
+export type Range = {
+  min: number;
+  max: number;
+};
+
+@Injectable()
+export class ProductDataAccess {
+  constructor(
+    @InjectRepository(ProductEntity)
+    private productRepository: Repository<PersistedProductEntity>,
+  ) {}
+
+  /**
+   *
+   * @param limit 상위 k 개의 제품으로 제한합니다.
+   * @param month 최근 m 개월을 판매된 상품으로 제한합니다.
+   * @param price 가격의 범위를 제한합니다.
+   * @returns 판매량 순위별 제품 정보 배열
+   *    - id: 제품 ID
+   *    - name: 제품명
+   *    - totalQuantity: 총 판매 수량
+   *    - salesRank: 판매량 순위 (1부터 시작)
+   */
+  async getPopularTopK(limit: number, month: number, price: Range) {
+    const popularTopProducts = await this.productRepository
+      .createQueryBuilder('p')
+      .select([
+        'p.id AS id',
+        'p.name as name',
+        'SUM(od.quantity) as totalQuantity',
+        'DENSE_RANK() OVER (ORDER BY SUM(od.quantity) DESC) as salesRank',
+      ])
+      .innerJoin(OrderDetailEntity, 'od', 'od.productId = p.id')
+      .where('p.price BETWEEN :minPrice AND :maxPrice', {
+        minPrice: price.min,
+        maxPrice: price.max,
+      })
+      .andWhere('od.createdAt >= DATE_SUB(NOW(), INTERVAL :month MONTH)', {
+        month,
+      })
+      .groupBy('p.id, p.name')
+      .orderBy('totalQuantity', 'DESC')
+      .limit(limit)
+      .getRawMany();
+
+    return popularTopProducts;
+  }
+}

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -1,38 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { PersistedProductEntity, ProductEntity } from './entity/product.entity';
-import { Repository } from 'typeorm';
-
-type Range = {
-  from: string;
-  to: string;
-};
+import { ProductDataAccess, Range } from './product.repository';
 
 @Injectable()
 export class ProductService {
-  constructor(
-    @InjectRepository(ProductEntity)
-    private productRepository: Repository<PersistedProductEntity>,
-  ) {}
+  constructor(private productDataAccess: ProductDataAccess) {}
 
-  async getPopularTopK(limit: string, month: string, price: Range) {
-    return await this.productRepository.query(
-      `SELECT p.id, p.name, sum(od.quantity) AS total_quantity
-        FROM products as p
-        JOIN
-            order_details AS od ON p.id = od.productId
-        JOIN
-            orders AS o ON o.id = od.productId
-        WHERE
-            p.price >= ? AND p.price <= ?
-            AND o.createdAt >= DATE_SUB(NOW(), INTERVAL ? MONTH )
-        GROUP BY
-            p.id, p.name
-        ORDER BY
-            total_quantity DESC
-        LIMIT ?
-        `,
-      [price.from, price.to, month, limit],
-    );
+  async getPopularTopK(limit: number, month: number, price: Range) {
+    return await this.productDataAccess.getPopularTopK(limit, month, price);
   }
 }

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany } from 'typeorm';
+import { Column, Entity, OneToMany, Relation } from 'typeorm';
 import { TRole, USER_ROLE } from '../types';
 import { IBaseEntity, MyBaseEntity } from '../../common/entity/base';
 import { UserEmailVO } from '../vo/email.vo';
@@ -51,7 +51,7 @@ export class UserEntity extends MyBaseEntity implements IUserEntity {
   role: TRole;
 
   @OneToMany(() => OrderEntity, (order) => order.user)
-  orders?: OrderEntity[];
+  orders?: Relation<OrderEntity>[];
 
   constructor(param?: IUserEntity) {
     super(param);


### PR DESCRIPTION
- https://github.com/f-lab-edu/commerce-app/pull/21#pullrequestreview-3023142999 에서 피드백 주신대로 쿼리빌더를 사용하였습니다.

- 기존에는 30초 timeout으로 페치할 수 없었던 쿼리를 ai의 도움을 받아 실행계획을 분석하여 쿼리에 맞는 인덱스를 생성하여 9초만에 페칭이 되도록 최적화 후에 쿼리와 인덱스를 계속 조절하여 현재는 3초대로 페칭이 가능합니다.