### PR TITLE
feat/#24 order.  멱등성을 지키는 로직 구현.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
     "@types/bcrypt": "^5.0.2",
-    "@types/cookie-parser": "^1.4.8",
+    "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "nodemailer": "^7.0.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.24"
+    "typeorm": "^0.3.24",
+    "zod": "^4.0.10"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/auth/service/auth/auth.applicationServiceImpl.ts
+++ b/src/auth/service/auth/auth.applicationServiceImpl.ts
@@ -28,7 +28,7 @@ import { ConfigService } from '@nestjs/config';
 import { ConfigException } from '../../../common/exception/internal.exception';
 import { JwtConfigData, LoginResData } from '../../types/auth.type';
 
-type JwtPayload = {
+export type JwtPayload = {
   id: number;
 };
 

--- a/src/common/decorator/customHeader.decorator.ts
+++ b/src/common/decorator/customHeader.decorator.ts
@@ -1,0 +1,15 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
+
+/**
+ * Nest.js built-in 데코레이터에 동일한 Header 데코레이터가 있지만
+ * Pipe와 연동이 불가하여, 새로 개발하게 됐습니다.
+ */
+export const CustomHeader = createParamDecorator(
+  (key: string, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest<Request>();
+    const header = req.headers[key];
+
+    return header;
+  },
+);

--- a/src/common/exception/idempotency.exception.ts
+++ b/src/common/exception/idempotency.exception.ts
@@ -1,3 +1,11 @@
+import { HttpStatus } from '@nestjs/common';
+import { HttpStatusCode } from '../decorator/httpCode.decorator';
 import { CustomException } from './service.exception';
 
 export abstract class IdempotencyException extends CustomException {}
+
+@HttpStatusCode(HttpStatus.CONFLICT)
+export class ConflictRequestException extends IdempotencyException {}
+
+@HttpStatusCode(HttpStatus.UNPROCESSABLE_ENTITY)
+export class UnprocessableException extends IdempotencyException {}

--- a/src/common/exception/idempotency.exception.ts
+++ b/src/common/exception/idempotency.exception.ts
@@ -1,0 +1,3 @@
+import { CustomException } from './service.exception';
+
+export abstract class IdempotencyException extends CustomException {}

--- a/src/common/exception/internal.exception.ts
+++ b/src/common/exception/internal.exception.ts
@@ -9,3 +9,6 @@ export class ConfigException extends InternalException {}
 
 @HttpStatusCode(HttpStatus.INTERNAL_SERVER_ERROR)
 export class TypeError extends InternalException {}
+
+@HttpStatusCode(HttpStatus.INTERNAL_SERVER_ERROR)
+export class InitializationException extends InternalException {}

--- a/src/common/pipe/empty.pipe.ts
+++ b/src/common/pipe/empty.pipe.ts
@@ -1,0 +1,19 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+
+@Injectable()
+export class CheckIfEmptyPipe implements PipeTransform {
+  transform(value: any, metadata: ArgumentMetadata) {
+    if (!value) {
+      throw new BadRequestException(
+        '입력된 값이 없습니다. 다시 확인해 주세요.',
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/common/pipe/jwt.pipe.ts
+++ b/src/common/pipe/jwt.pipe.ts
@@ -1,0 +1,48 @@
+import {
+  ArgumentMetadata,
+  Injectable,
+  PipeTransform,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { JwtPayload } from '../../auth/service/auth/auth.applicationServiceImpl';
+import { ConfigService } from '@nestjs/config';
+import { ConfigException } from '../exception/internal.exception';
+
+@Injectable()
+export class JwtPipe implements PipeTransform {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  private getSecret() {
+    const secret = this.configService.get('JWT_SECRET');
+    if (!secret) {
+      throw new ConfigException({
+        clientMsg: '서버에 문제가 생겼습니다. 다시 시도해주세요.',
+        devMsg: '토큰 시크릿이 없습니다. 환경변수 파일을 확인해주세요',
+      });
+    }
+    return secret;
+  }
+
+  transform(value: any, metadata: ArgumentMetadata) {
+    if (!value) {
+      throw new UnauthorizedException('인증 토큰이 필요합니다.');
+    }
+
+    if (!value.startsWith('Bearer ')) {
+      throw new UnauthorizedException('올바른 인증 토큰이 아닙니다.');
+    }
+
+    // Bearer token... 'Bearer '제거
+    const token = value.substring(7);
+    const secret = this.getSecret();
+    try {
+      return this.jwtService.verify<JwtPayload>(token, { secret });
+    } catch (error) {
+      throw new UnauthorizedException('유효하지 않은 인증 토큰입니다.');
+    }
+  }
+}

--- a/src/order/command/order.command.ts
+++ b/src/order/command/order.command.ts
@@ -3,15 +3,22 @@ import { OrderDto } from '../dto/order.dto';
 type OrderInput = {
   key: string;
   orderDto: OrderDto;
+  userId: number;
 };
 
 export class OrderCommand {
   private _idempotencyKey: string;
   private _orderDto: OrderDto;
+  private _userId: number;
 
   constructor(param: OrderInput) {
     this._idempotencyKey = param.key;
     this._orderDto = param.orderDto;
+    this._userId = param.userId;
+  }
+
+  get userId() {
+    return this._userId;
   }
 
   get idempotencyKey() {

--- a/src/order/command/order.command.ts
+++ b/src/order/command/order.command.ts
@@ -1,0 +1,24 @@
+import { OrderDto } from '../dto/order.dto';
+
+type OrderInput = {
+  key: string;
+  orderDto: OrderDto;
+};
+
+export class OrderCommand {
+  private _idempotencyKey: string;
+  private _orderDto: OrderDto;
+
+  constructor(param: OrderInput) {
+    this._idempotencyKey = param.key;
+    this._orderDto = param.orderDto;
+  }
+
+  get idempotencyKey() {
+    return this._idempotencyKey;
+  }
+
+  get orderDto() {
+    return this._orderDto;
+  }
+}

--- a/src/order/dto/order.dto.ts
+++ b/src/order/dto/order.dto.ts
@@ -1,0 +1,80 @@
+import {
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsPhoneNumber,
+  IsString,
+  Length,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { IBaseEntity } from '../../common/entity/base';
+import { IOrderDetail } from '../../orderDetail/entity/orderDetail.entity';
+import { IOrderEntity } from '../entity/order.entity';
+import { UserNameVO } from '../../user/vo/name.vo';
+import { AddressVO } from '../vo/address.vo';
+import { PostalCodeVO } from '../vo/postalCode.vo';
+
+type WithoutBaseEntity<T> = Omit<T, keyof IBaseEntity>;
+
+type IOrderInput = Omit<
+  WithoutBaseEntity<IOrderEntity>,
+  'userId' | 'orderStatus'
+>;
+type IOrderDetailInput = Omit<WithoutBaseEntity<IOrderDetail>, 'orderId'>;
+
+export class OrderDto implements IOrderInput {
+  @IsInt()
+  @Min(0)
+  subtotal: number;
+
+  @IsInt()
+  @Min(0)
+  shippingFee: number;
+
+  @IsInt()
+  @Min(0)
+  totalAmount: number;
+
+  @IsString()
+  @Length(UserNameVO.constraints.minLen, UserNameVO.constraints.maxLen)
+  recipientName: string;
+
+  @IsPhoneNumber('KR')
+  recipientPhone: string;
+
+  @IsString()
+  @Length(AddressVO.constraints.minLen, AddressVO.constraints.maxLen)
+  shippingAddress: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(AddressVO.constraints.minLen, AddressVO.constraints.maxLen)
+  shippingDetailAddress?: string | undefined;
+
+  @IsString()
+  @Length(PostalCodeVO.constraints.minLen, PostalCodeVO.constraints.minLen)
+  postalCode: string;
+
+  @IsArray()
+  @ValidateNested()
+  orderItems: OrderDetailInputs[];
+}
+
+export class OrderDetailInputs implements IOrderDetailInput {
+  @IsInt()
+  @Min(0)
+  productId: number;
+
+  @IsInt()
+  @Min(0)
+  quantity: number;
+
+  @IsInt()
+  @Min(0)
+  subtotal: number;
+
+  @IsInt()
+  @Min(0)
+  unitPrice: number;
+}

--- a/src/order/entity/idempotency.entity.ts
+++ b/src/order/entity/idempotency.entity.ts
@@ -1,0 +1,39 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { CommonConstraints } from '../../common/entity/base.constraints';
+
+export const IDEMPOTENCY_STATUS = {
+  PROCESSING: 'processing',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+} as const;
+
+type IdempotencyStatus = typeof IDEMPOTENCY_STATUS;
+export type TIdempotencyStatus = IdempotencyStatus[keyof IdempotencyStatus];
+
+@Entity('idempotency_keys')
+export class IdempotencyKeyEntity {
+  @PrimaryColumn()
+  idempotencyKey: string;
+
+  @Column({ type: CommonConstraints.DB_CONSTRAINTS.BASIC_NUMBER })
+  userId: number;
+
+  @Column({
+    type: 'enum',
+    default: IDEMPOTENCY_STATUS.PROCESSING,
+    enum: IDEMPOTENCY_STATUS,
+  })
+  status: TIdempotencyStatus;
+
+  @Column({ type: 'json' })
+  responseBody: Record<string, string>;
+
+  @Column({ type: 'datetime' })
+  createdAt: Date;
+
+  @Column({ type: 'datetime' })
+  updatedAt: Date;
+
+  @Column({ type: 'datetime' })
+  expiresAt: Date;
+}

--- a/src/order/entity/idempotency.entity.ts
+++ b/src/order/entity/idempotency.entity.ts
@@ -12,7 +12,9 @@ export type TIdempotencyStatus = IdempotencyStatus[keyof IdempotencyStatus];
 
 @Entity('idempotency_keys')
 export class IdempotencyKeyEntity {
-  @PrimaryColumn()
+  @PrimaryColumn({
+    type: CommonConstraints.DB_CONSTRAINTS.BASIC_STRING,
+  })
   idempotencyKey: string;
 
   @Column({ type: CommonConstraints.DB_CONSTRAINTS.BASIC_NUMBER })
@@ -24,6 +26,11 @@ export class IdempotencyKeyEntity {
     enum: IDEMPOTENCY_STATUS,
   })
   status: TIdempotencyStatus;
+
+  @Column({
+    type: CommonConstraints.DB_CONSTRAINTS.BASIC_STRING,
+  })
+  hashedPayload: string;
 
   @Column({ type: 'json' })
   responseBody: Record<string, string>;

--- a/src/order/entity/idempotency.entity.ts
+++ b/src/order/entity/idempotency.entity.ts
@@ -1,5 +1,7 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 import { CommonConstraints } from '../../common/entity/base.constraints';
+import { z } from 'zod';
+import { InternalException } from '../../common/exception/internal.exception';
 
 export const IDEMPOTENCY_STATUS = {
   PROCESSING: 'processing',
@@ -10,8 +12,25 @@ export const IDEMPOTENCY_STATUS = {
 type IdempotencyStatus = typeof IDEMPOTENCY_STATUS;
 export type TIdempotencyStatus = IdempotencyStatus[keyof IdempotencyStatus];
 
+const IdempotencyKeySchema = z.object({
+  idempotencyKey: z.string(),
+  status: z.enum(Object.keys(IDEMPOTENCY_STATUS)),
+  userId: z.number(),
+  hashedPayload: z.string(),
+  responseBody: z.json(),
+  createdAt: z.date().optional(),
+  updatedAt: z.date().optional(),
+  expiresAt: z.date(),
+});
+
+type IIdempotencyKeyEntity = z.infer<typeof IdempotencyKeySchema>;
+type IdempotencyKeyInput = Omit<
+  IIdempotencyKeyEntity,
+  'createdAt' | 'updatedAt' | 'status'
+>;
+
 @Entity('idempotency_keys')
-export class IdempotencyKeyEntity {
+export class IdempotencyKeyEntity implements IIdempotencyKeyEntity {
   @PrimaryColumn({
     type: CommonConstraints.DB_CONSTRAINTS.BASIC_STRING,
   })
@@ -36,11 +55,27 @@ export class IdempotencyKeyEntity {
   responseBody: Record<string, string>;
 
   @Column({ type: 'datetime' })
-  createdAt: Date;
+  createdAt?: Date;
 
   @Column({ type: 'datetime' })
-  updatedAt: Date;
+  updatedAt?: Date;
 
   @Column({ type: 'datetime' })
   expiresAt: Date;
+
+  // constructor를 비공개로 하고 객체 생성로직을 팩토리 함수로 작성하고 싶어도
+  // typeorm은 엔터티를 초기화할때 생성자를 사용하므로 생성자를 공개할 수 밖에 없음
+  // 복잡한 로직을 팩토리함수에 작성하고, 생성자에는 간단한 로직만 남겨둬도
+  // 생성자로 초기화하는 실수를 할 수 있기때문에, 생성자에 로직을 뒀습니다.
+  constructor(param: IdempotencyKeyInput) {
+    try {
+      const safeParsedParam = IdempotencyKeySchema.parse(param);
+      Object.assign(this, safeParsedParam);
+    } catch (error) {
+      throw new InternalException({
+        clientMsg: '서버에 문제가 생겼습니다 다시 시도해 주세요. ',
+        devMsg: `${JSON.stringify(error)}`,
+      });
+    }
+  }
 }

--- a/src/order/entity/order.entity.ts
+++ b/src/order/entity/order.entity.ts
@@ -31,6 +31,8 @@ export interface IOrderEntity extends IBaseEntity {
   postalCode: string;
 }
 
+export type PersistedOrderEntity = Required<Omit<OrderEntity, 'orderDetails'>>;
+
 @Entity({ name: 'orders' })
 export class OrderEntity extends MyBaseEntity implements IOrderEntity {
   @Column({

--- a/src/order/idempotency.service.ts
+++ b/src/order/idempotency.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  IDEMPOTENCY_STATUS,
+  IdempotencyKeyEntity,
+} from './entity/idempotency.entity';
+import { Repository } from 'typeorm';
+
+import { OrderCommand } from './command/order.command';
+import { OrderDto } from './dto/order.dto';
+import { createHash } from 'crypto';
+import {
+  ConflictRequestException,
+  UnprocessableException,
+} from '../common/exception/idempotency.exception';
+
+@Injectable()
+export class IdempotencyService {
+  constructor(
+    @InjectRepository(IdempotencyKeyEntity)
+    private readonly idempotencyRepository: Repository<IdempotencyKeyEntity>,
+  ) {}
+
+  async find(key: string): Promise<IdempotencyKeyEntity | null> {
+    return await this.idempotencyRepository.findOne({
+      where: { idempotencyKey: key },
+    });
+  }
+
+  checkIfCanMakeOrder(
+    idempotencyKeyEntity: IdempotencyKeyEntity | null,
+    payload: OrderDto,
+  ) {
+    this.checkIfProcessing(idempotencyKeyEntity);
+    this.isProcessable(idempotencyKeyEntity, payload);
+  }
+
+  private hasPreviousReq(idempotencyKeyEntity: IdempotencyKeyEntity | null) {
+    return idempotencyKeyEntity !== null;
+  }
+
+  private checkIfProcessing(idempotencyKeyEntity: IdempotencyKeyEntity | null) {
+    if (
+      this.hasPreviousReq(idempotencyKeyEntity) &&
+      idempotencyKeyEntity.status === IDEMPOTENCY_STATUS.PROCESSING
+    ) {
+      throw new ConflictRequestException({
+        clientMsg: '진행중인 주문이 있습니다. 잠시만 기다려주세요',
+        devMsg: `진행중인 주문 키: ${idempotencyKeyEntity.idempotencyKey}`,
+      });
+    }
+  }
+  private isProcessable(
+    idempotencyKeyEntity: IdempotencyKeyEntity | null,
+    payload: OrderDto,
+  ) {
+    const hashedIncomingPayload = this.hashPayload(payload);
+
+    if (
+      this.hasPreviousReq(idempotencyKeyEntity) &&
+      idempotencyKeyEntity.hashedPayload != hashedIncomingPayload
+    ) {
+      throw new UnprocessableException({
+        clientMsg: '주문정보가 일치하지 않습니다. 다시 시도해주세요',
+        devMsg: `주문키: ${idempotencyKeyEntity.idempotencyKey}`,
+      });
+    }
+  }
+
+  private hashPayload(payload: OrderDto) {
+    const sortedPayload = Object.keys(payload)
+      .sort()
+      .reduce((obj, key) => {
+        obj[key] = payload[key];
+
+        return obj;
+      }, {});
+
+    const payloadString = JSON.stringify(sortedPayload);
+    return createHash('sha256').update(payloadString).digest('hex');
+  }
+}

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Headers, Post } from '@nestjs/common';
 import { OrderDto } from './dto/order.dto';
 
 @Controller('order')
@@ -6,5 +6,9 @@ export class OrderController {
   constructor() {}
 
   @Post()
-  async makeOrder(@Body() orderDto: OrderDto) {}
+  async makeOrder(
+    @Headers('Idempotency-Key') idempotencyKey: string | undefined,
+    @Body()
+    orderDto: OrderDto,
+  ) {}
 }

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -4,6 +4,8 @@ import { OrderService } from './order.service';
 import { CheckIfEmptyPipe } from '../common/pipe/empty.pipe';
 import { CustomHeader } from '../common/decorator/customHeader.decorator';
 import { OrderCommand } from './command/order.command';
+import { JwtPipe } from '../common/pipe/jwt.pipe';
+import { JwtPayload } from '../auth/service/auth/auth.applicationServiceImpl';
 
 @Controller('order')
 export class OrderController {
@@ -13,11 +15,17 @@ export class OrderController {
   async makeOrder(
     @CustomHeader('idempotency-key', CheckIfEmptyPipe, ParseUUIDPipe)
     idempotencyKey: string,
+    @CustomHeader('authorization', CheckIfEmptyPipe, JwtPipe)
+    jwtPayload: JwtPayload,
     @Body()
     orderDto: OrderDto,
   ) {
     return await this.orderService.makeOrder(
-      new OrderCommand({ key: idempotencyKey, orderDto }),
+      new OrderCommand({
+        key: idempotencyKey,
+        orderDto,
+        userId: jwtPayload.id,
+      }),
     );
   }
 }

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -1,0 +1,10 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { OrderDto } from './dto/order.dto';
+
+@Controller('order')
+export class OrderController {
+  constructor() {}
+
+  @Post()
+  async makeOrder(@Body() orderDto: OrderDto) {}
+}

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -1,14 +1,23 @@
-import { Body, Controller, Headers, Post } from '@nestjs/common';
+import { Body, Controller, ParseUUIDPipe, Post } from '@nestjs/common';
 import { OrderDto } from './dto/order.dto';
+import { OrderService } from './order.service';
+import { CheckIfEmptyPipe } from '../common/pipe/empty.pipe';
+import { CustomHeader } from '../common/decorator/customHeader.decorator';
+import { OrderCommand } from './command/order.command';
 
 @Controller('order')
 export class OrderController {
-  constructor() {}
+  constructor(private readonly orderService: OrderService) {}
 
   @Post()
   async makeOrder(
-    @Headers('Idempotency-Key') idempotencyKey: string | undefined,
+    @CustomHeader('idempotency-key', CheckIfEmptyPipe, ParseUUIDPipe)
+    idempotencyKey: string,
     @Body()
     orderDto: OrderDto,
-  ) {}
+  ) {
+    return await this.orderService.makeOrder(
+      new OrderCommand({ key: idempotencyKey, orderDto }),
+    );
+  }
 }

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -5,10 +5,11 @@ import { OrderController } from './order.controller';
 import { IdempotencyKeyEntity } from './entity/idempotency.entity';
 import { OrderService } from './order.service';
 import { IdempotencyService } from './idempotency.service';
+import { JwtPipe } from '../common/pipe/jwt.pipe';
 
 @Module({
   imports: [TypeOrmModule.forFeature([OrderEntity, IdempotencyKeyEntity])],
-  providers: [OrderService, IdempotencyService],
+  providers: [OrderService, IdempotencyService, JwtPipe],
   controllers: [OrderController],
 })
 export class OrderModule {}

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -3,9 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrderEntity } from './entity/order.entity';
 import { OrderController } from './order.controller';
 import { IdempotencyKeyEntity } from './entity/idempotency.entity';
+import { OrderService } from './order.service';
+import { IdempotencyService } from './idempotency.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([OrderEntity, IdempotencyKeyEntity])],
+  providers: [OrderService, IdempotencyService],
   controllers: [OrderController],
 })
 export class OrderModule {}

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrderEntity } from './entity/order.entity';
 import { OrderController } from './order.controller';
+import { IdempotencyKeyEntity } from './entity/idempotency.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([OrderEntity])],
+  imports: [TypeOrmModule.forFeature([OrderEntity, IdempotencyKeyEntity])],
   controllers: [OrderController],
 })
 export class OrderModule {}

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrderEntity } from './entity/order.entity';
+import { OrderController } from './order.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([OrderEntity])],
+  controllers: [OrderController],
 })
 export class OrderModule {}

--- a/src/order/order.repository.ts
+++ b/src/order/order.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable, NotImplementedException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { OrderEntity } from './entity/order.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class OrderDataAccess {
+  constructor(
+    @InjectRepository(OrderEntity)
+    private readonly orderRepository: Repository<OrderEntity>,
+  ) {}
+
+  async saveOrder() {
+    throw new NotImplementedException();
+  }
+}

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class OrderService {}

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -1,4 +1,31 @@
 import { Injectable } from '@nestjs/common';
+import { IdempotencyService } from './idempotency.service';
+import { OrderCommand } from './command/order.command';
+import {
+  IDEMPOTENCY_STATUS,
+  IdempotencyKeyEntity,
+} from './entity/idempotency.entity';
+import { OrderDataAccess } from './order.repository';
 
 @Injectable()
-export class OrderService {}
+export class OrderService {
+  constructor(
+    private readonly idempotencyService: IdempotencyService,
+    private readonly orderDataAccess: OrderDataAccess,
+  ) {}
+
+  async makeOrder(orderCommand: OrderCommand) {
+    const { idempotencyKey, orderDto } = orderCommand;
+    const idempotencyKeyEntity =
+      await this.idempotencyService.find(idempotencyKey);
+
+    this.idempotencyService.checkIfCanMakeOrder(idempotencyKeyEntity, orderDto);
+
+    /**
+     * 주문 로직 실행.
+     * 멱등성 로직을 우선 구현
+     * saveOrder는 미구현 상태
+     */
+    const result = await this.orderDataAccess.saveOrder();
+  }
+}

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -1,10 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { IdempotencyService } from './idempotency.service';
 import { OrderCommand } from './command/order.command';
-import {
-  IDEMPOTENCY_STATUS,
-  IdempotencyKeyEntity,
-} from './entity/idempotency.entity';
 import { OrderDataAccess } from './order.repository';
 
 @Injectable()
@@ -15,7 +11,7 @@ export class OrderService {
   ) {}
 
   async makeOrder(orderCommand: OrderCommand) {
-    const { idempotencyKey, orderDto } = orderCommand;
+    const { idempotencyKey, orderDto, userId } = orderCommand;
     const idempotencyKeyEntity =
       await this.idempotencyService.find(idempotencyKey);
 
@@ -24,8 +20,14 @@ export class OrderService {
     /**
      * 주문 로직 실행.
      * 멱등성 로직을 우선 구현
-     * saveOrder는 미구현 상태
+     * 주문을 생성하는 로직은 아직 미구현
      */
-    const result = await this.orderDataAccess.saveOrder();
+    const result = (await this.orderDataAccess.saveOrder()) as any; // response
+    await this.idempotencyService.save({
+      key: idempotencyKey,
+      orderDto,
+      response: result,
+      userId,
+    });
   }
 }

--- a/src/order/vo/address.vo.ts
+++ b/src/order/vo/address.vo.ts
@@ -20,9 +20,9 @@ export class AddressVO {
       address.length < this.constraints.minLen ||
       address.length > this.constraints.maxLen
     ) {
-      throw new InitializationException(
-        `${AddressVO.name} 초기화 중 문제가 발생했어요. 주소의 길이는 ${this.constraints.minLen} ~ ${this.constraints.maxLen} 사이여야 합니다.`,
-      );
+      throw new InitializationException({
+        clientMsg: `${AddressVO.name} 초기화 중 문제가 발생했어요. 주소의 길이는 ${this.constraints.minLen} ~ ${this.constraints.maxLen} 사이여야 합니다.`,
+      });
     }
 
     return new AddressVO(address);

--- a/src/order/vo/address.vo.ts
+++ b/src/order/vo/address.vo.ts
@@ -1,0 +1,30 @@
+import { InitializationException } from '../../common/exception/internal.exception';
+
+const ADDRESS_MIN_LEN = 1;
+const ADDRESS_MAX_LEN = 255;
+export class AddressVO {
+  static readonly constraints = {
+    minLen: ADDRESS_MIN_LEN,
+    maxLen: ADDRESS_MAX_LEN,
+  } as const;
+
+  constructor(private address: string) {}
+
+  valueOf() {
+    return this.address;
+  }
+
+  static from(addressInput: string) {
+    const address = addressInput.trim();
+    if (
+      address.length < this.constraints.minLen ||
+      address.length > this.constraints.maxLen
+    ) {
+      throw new InitializationException(
+        `${AddressVO.name} 초기화 중 문제가 발생했어요. 주소의 길이는 ${this.constraints.minLen} ~ ${this.constraints.maxLen} 사이여야 합니다.`,
+      );
+    }
+
+    return new AddressVO(address);
+  }
+}

--- a/src/order/vo/postalCode.vo.ts
+++ b/src/order/vo/postalCode.vo.ts
@@ -1,0 +1,33 @@
+import { InitializationException } from '../../common/exception/internal.exception';
+
+/**
+ * 대한민국의 우편번호 체계는 5자리입니다.
+ */
+const POSTAL_CODE_MIN_LEN = 1;
+const POSTAL_CODE_MAX_LEN = 5;
+export class PostalCodeVO {
+  static readonly constraints = {
+    minLen: POSTAL_CODE_MIN_LEN,
+    maxLen: POSTAL_CODE_MAX_LEN,
+  } as const;
+
+  constructor(private postalCode: string) {}
+
+  valueOf() {
+    return this.postalCode;
+  }
+
+  static from(postalCodeInput: string) {
+    const postalCode = postalCodeInput.trim();
+    if (
+      postalCode.length < this.constraints.maxLen ||
+      postalCode.length > this.constraints.maxLen
+    ) {
+      throw new InitializationException(
+        `${PostalCodeVO.name} 초기화 중 문제가 발생했어요. 우편번호의 길이는 ${this.constraints.minLen} ~ ${this.constraints.maxLen} 사이여야 합니다.`,
+      );
+    }
+
+    return new PostalCodeVO(postalCode);
+  }
+}

--- a/src/order/vo/postalCode.vo.ts
+++ b/src/order/vo/postalCode.vo.ts
@@ -23,9 +23,9 @@ export class PostalCodeVO {
       postalCode.length < this.constraints.maxLen ||
       postalCode.length > this.constraints.maxLen
     ) {
-      throw new InitializationException(
-        `${PostalCodeVO.name} 초기화 중 문제가 발생했어요. 우편번호의 길이는 ${this.constraints.minLen} ~ ${this.constraints.maxLen} 사이여야 합니다.`,
-      );
+      throw new InitializationException({
+        clientMsg: `${PostalCodeVO.name} 초기화 중 문제가 발생했어요. 우편번호의 길이는 ${this.constraints.minLen} ~ ${this.constraints.maxLen} 사이여야 합니다.`,
+      });
     }
 
     return new PostalCodeVO(postalCode);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,10 +1406,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie-parser@^1.4.8":
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/@types/cookie-parser/-/cookie-parser-1.4.8.tgz#d2215e7915f624fbfe4233da8f063f511679f1f3"
-  integrity sha512-l37JqFrOJ9yQfRQkljb41l0xVphc7kg5JTjjr+pLRZ0IyZ49V4BQ8vbF4Ut2C2e+WH4al3xD3ZwYwIUfnbT4NQ==
+"@types/cookie-parser@^1.4.9":
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/@types/cookie-parser/-/cookie-parser-1.4.9.tgz#f0e79c766a58ee7369a52e7509b3840222f68ed2"
+  integrity sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==
 
 "@types/cookiejar@^2.1.5":
   version "2.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6321,3 +6321,8 @@ yoctocolors-cjs@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
+
+zod@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.0.10.tgz#b609ee8807c1fe6a9d8beec2be51220cc7a8f0ca"
+  integrity sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==


### PR DESCRIPTION
***주문 생성 로직 구현 중, PR의 크기가 너무 커질 것 같아 멱등성 관련 로직부터 우선 구현하였습니다.***

# 주요 구현 사항
- 멱등키가 있는지 확인합니다.
- 요청이 처리 중인데 같은 멱등키로 새롭게 요청이 온지 확인합니다.
- 같은 멱등키로 새로운 요청이 왔는데 요청 본문이 다른지 확인합니다. 
- 주문 로직은 있다고 가정했습니다.

# 핵심 변경 파일
`src/order/order.service.ts`
`src/order/order.controller.ts`


# 특이사항
- `IdempotencyEntity` 생성자에 복잡한 로직을 의도적으로 뒀습니다. 
    ( 이 부분은 코멘트로 코드와 함께 의도를 작성하도록 하겠습니다. )


# Todo
- 주문 로직을 완성합니다.
- 트랜잭션을 적용합니다.
- 재고감소를 다룰때 동시성을 위해 Locking을 적용합니다.

