### PR TITLE
주문생성 로직 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:hello": "ts-node ./test.ts"
   },
   "dependencies": {
+    "@nestjs-cls/transactional": "^3.1.0",
+    "@nestjs-cls/transactional-adapter-typeorm": "^1.3.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { getDataSourceToken, TypeOrmModule } from '@nestjs/typeorm';
 import { TypeOrmConfigService } from './database/typeormConfig.service';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
@@ -10,6 +10,8 @@ import { OrderDetailModule } from './orderDetail/orderDetail.module';
 import { ClsModule } from 'nestjs-cls';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { TransactionInterceptor } from './common/decorator/transaction.decorator';
+import { ClsPluginTransactional } from '@nestjs-cls/transactional';
+import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 
 @Module({
   imports: [
@@ -20,6 +22,14 @@ import { TransactionInterceptor } from './common/decorator/transaction.decorator
     ClsModule.forRoot({
       global: true,
       middleware: { mount: true },
+      plugins: [
+        new ClsPluginTransactional({
+          imports: [TypeOrmModule],
+          adapter: new TransactionalAdapterTypeOrm({
+            dataSourceToken: getDataSourceToken(),
+          }),
+        }),
+      ],
     }),
     UserModule,
     AuthModule,

--- a/src/common/entity/base.ts
+++ b/src/common/entity/base.ts
@@ -3,12 +3,15 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import z from 'zod';
 
-export interface IBaseEntity {
-  id?: number;
-  createdAt?: Date;
-  updatedAt?: Date;
-}
+export const BaseSchema = z.object({
+  id: z.number().optional(),
+  createdAt: z.date().optional(),
+  updatedAt: z.date().optional(),
+});
+
+export type IBaseEntity = z.infer<typeof BaseSchema>;
 
 /**
  * TypeOrm BaseEntity와 이름중복이 있어서 'My'라는 프리픽스를 사용함

--- a/src/order/dto/order.dto.ts
+++ b/src/order/dto/order.dto.ts
@@ -6,18 +6,16 @@ import {
   IsString,
   Length,
   Min,
-  registerDecorator,
   ValidateNested,
-  ValidationOptions,
 } from 'class-validator';
 import { IBaseEntity } from '../../common/entity/base';
 import { IOrderDetail } from '../../orderDetail/entity/orderDetail.entity';
-import { IOrderEntity } from '../entity/order.entity';
 import { UserNameVO } from '../../user/vo/name.vo';
 import { AddressVO } from '../vo/address.vo';
 import { PostalCodeVO } from '../vo/postalCode.vo';
 import { IsValidTotalAmount } from '../utils/isValidTotalAmount.decorator';
 import { Type } from 'class-transformer';
+import { IOrderEntity } from '../entity/order.entity';
 
 type WithoutBaseEntity<T> = Omit<T, keyof IBaseEntity>;
 

--- a/src/order/entity/orderRequest.entity.ts
+++ b/src/order/entity/orderRequest.entity.ts
@@ -54,7 +54,7 @@ export class OrderRequestEntity implements IOrderRequestEntity {
   hashedPayload: string;
 
   @Column({ type: 'json' })
-  responseBody: Record<string, string>;
+  responseBody: any;
 
   @Column({ type: 'datetime' })
   createdAt?: Date;

--- a/src/order/order.repository.ts
+++ b/src/order/order.repository.ts
@@ -1,19 +1,17 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
-import { OrderEntity } from './entity/order.entity';
-import { DataSource } from 'typeorm';
-import { ClsService } from 'nestjs-cls';
-import { BaseRepository } from '../common/repository/base.repository';
+import { Injectable } from '@nestjs/common';
+import { OrderEntity, PersistedOrderEntity } from './entity/order.entity';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 
 @Injectable()
-export class OrderRepository extends BaseRepository<OrderEntity> {
+export class OrderRepository {
   constructor(
-    protected readonly dataSource: DataSource,
-    protected readonly clsService: ClsService,
-  ) {
-    super(clsService, dataSource);
-  }
+    private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
+  ) {}
 
-  async saveOrder() {
-    throw new NotImplementedException();
+  async saveOrder(order: OrderEntity): Promise<PersistedOrderEntity> {
+    return (await this.txHost.tx
+      .getRepository(OrderEntity)
+      .save(order)) as PersistedOrderEntity;
   }
 }

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -4,9 +4,8 @@ import { OrderRequestService } from './orderRequest.service';
 import { ProductPriceService } from '../product/productPrice.service';
 import { OrderPolicyService } from './policy/order.policy';
 import { OrderRepository } from './order.repository';
-import { Transactional } from '../common/decorator/transaction.decorator';
 import { ProductService } from '../product/product.service';
-import { OrderItemsInput } from './dto/order.dto';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class OrderService {

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -6,6 +6,8 @@ import { OrderPolicyService } from './policy/order.policy';
 import { OrderRepository } from './order.repository';
 import { ProductService } from '../product/product.service';
 import { Transactional } from '@nestjs-cls/transactional';
+import { OrderDto } from './dto/order.dto';
+import { OrderEntity, OrderParam } from './entity/order.entity';
 
 @Injectable()
 export class OrderService {
@@ -38,18 +40,26 @@ export class OrderService {
      * 2. 재고가 충분하면 재고 감소, 재고가 충분하지 않으면 에러
      * 3. 재고가 불충분하면 롤백 및 주문 전체 취소
      */
-    await this.productService.validateAndDecreaseStocks(orderDto.orderItems);
+    const { orderItems, ...orderInfos } = orderDto;
+    await this.productService.validateAndDecreaseStocks(orderItems);
 
-    /**
-     * TODO
-     * create Order,OrderItems
-     */
-    const result = (await this.orderRepository.saveOrder()) as any; // response
+    // TODO
+    // create orderDto
+
+    const result = await this.saveOrder(orderInfos, userId);
     await this.orderRequestService.save({
       id: orderRequestId,
       orderDto,
       responseBody: result,
       userId,
     });
+  }
+  private async saveOrder(
+    orderDto: Omit<OrderDto, 'orderItems'>,
+    userId: number,
+  ) {
+    const orderParam: OrderParam = { ...orderDto, userId };
+    const order = OrderEntity.create(orderParam);
+    return await this.orderRepository.saveOrder(order);
   }
 }

--- a/src/product/entity/productPrice.entity.ts
+++ b/src/product/entity/productPrice.entity.ts
@@ -1,13 +1,7 @@
 import { Column, Entity } from 'typeorm';
-import { MyBaseEntity } from '../../common/entity/base';
+import { IBaseEntity, MyBaseEntity } from '../../common/entity/base';
 import { CommonConstraints } from '../../common/entity/base.constraints';
 import { z } from 'zod';
-
-const BaseSchema = z.object({
-  id: z.number().optional(),
-  createdAt: z.date().optional(),
-  updatedAt: z.date().optional(),
-});
 
 const ProductPriceSchema = z.object({
   productId: z.number(),
@@ -16,9 +10,8 @@ const ProductPriceSchema = z.object({
   isCurrent: z.boolean(),
 });
 
-type BaseType = z.infer<typeof BaseSchema>;
 type ProductPriceType = z.infer<typeof ProductPriceSchema>;
-type IProductPriceEntity = BaseType & ProductPriceType;
+type IProductPriceEntity = IBaseEntity & ProductPriceType;
 export type PersistedProductPriceEntity = Required<IProductPriceEntity>;
 
 @Entity({ name: 'product_prices' })
@@ -48,7 +41,7 @@ export class ProductPriceEntity
   })
   isCurrent: boolean;
 
-  private constructor(param?: BaseType) {
+  private constructor(param?: IBaseEntity) {
     super(param);
   }
 

--- a/src/product/product.repository.ts
+++ b/src/product/product.repository.ts
@@ -56,14 +56,12 @@ export class ProductRepository {
   }
 
   async findMany(productIds: number[]) {
-    /**
-     * 상품 조회시 lock 추후 적용.
-     * 현재는 우선 트랜잭션 로직만 작성
-     */
-
     const products = await this.txHost.tx.getRepository(ProductEntity).find({
       where: {
         id: In(productIds),
+      },
+      lock: {
+        mode: 'pessimistic_write',
       },
     });
     return products as PersistedProductEntity[];

--- a/src/product/productPrice.repository.ts
+++ b/src/product/productPrice.repository.ts
@@ -1,26 +1,23 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, In } from 'typeorm';
+import { In } from 'typeorm';
 import {
   PersistedProductPriceEntity,
   ProductPriceEntity,
 } from './entity/productPrice.entity';
-import { BaseRepository } from '../common/repository/base.repository';
-import { ClsService } from 'nestjs-cls';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 
 @Injectable()
-export class ProductPriceRepository extends BaseRepository<PersistedProductPriceEntity> {
+export class ProductPriceRepository {
   constructor(
-    protected readonly clsService: ClsService,
-    protected readonly dataSource: DataSource,
-  ) {
-    super(clsService, dataSource);
-  }
+    private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
+  ) {}
 
   async findMany(productIds: number[]) {
-    return await this.getRepository(ProductPriceEntity).find({
+    return (await this.txHost.tx.getRepository(ProductPriceEntity).find({
       where: {
         productId: In(productIds),
       },
-    });
+    })) as PersistedProductPriceEntity[];
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,6 +1009,16 @@
     "@napi-rs/nice-win32-ia32-msvc" "1.0.1"
     "@napi-rs/nice-win32-x64-msvc" "1.0.1"
 
+"@nestjs-cls/transactional-adapter-typeorm@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@nestjs-cls/transactional-adapter-typeorm/-/transactional-adapter-typeorm-1.3.0.tgz#51d3ee6a3b4ed0414569c9242d3d411604fffec3"
+  integrity sha512-45nzqAWUTDDnhj5pdtfAMXJjx+vMXv00zudqt5hbsZXyIVbMOiJXyrN1QHf0Or5rgd285VoiyQDY8hptPK9ieQ==
+
+"@nestjs-cls/transactional@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@nestjs-cls/transactional/-/transactional-3.1.0.tgz#68909efaced90e7f915d0fc6d0887cd022ae203e"
+  integrity sha512-HWtS73KWva1Z6Y8PEkVGjDd4dZDb7Qv4rhwCinpsmv5m2wSvxGxqbnG+oTSe7ZCB1EoLihOL9L08GyB6o6bLQA==
+
 "@nestjs/cli@^11.0.0":
   version "11.0.7"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-11.0.7.tgz#204a1969c2609d7cf5e98a4d65819bd8585bead7"


### PR DESCRIPTION
- 데이터베이스 lock 학습 후 lock을 적용했습니다.  ( `src/product/product.repository.ts` )
    - 트랜잭션이 끝날때까지 다른 트랜잭션이 레코드를 조회 할 수 없는 `pessimistic lock`을 사용했습니다.
- 주문 정보를 생성 ( `src/order/order.repository.ts ` )
- 트랜잭션 데코레이터 모듈을 직접 구현한 인터셉터에서 `nestjs-cls` 구현체로 바꾸었습니다.
    - `nestjs-cls`는 트랜잭션 전파레벨을 설정 할 수 있어서 모듈을 바꾸었습니다.
- 테스트 코드 작성은 아직 주문 생성이 미완성이라 마지막 단계인 `주문 상세`로직 작성 후 `주문 생성` 테스트 코드를 작성하겠습니다.